### PR TITLE
fix example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ City Score uses a three-step process:
     from city_score import run
     from city_score.sources.peopleforbikes import *
     from city_score.sources.zillow import *
+    from city_score.sources.core import *
 
     sources = (
         PeopleForBikes,


### PR DESCRIPTION
After copying and pasting the example script, got `NameError: name 'minimum_population' is not defined`. This PR updates the example to include the core import.