### PR TITLE
Add Trust for Public Land source

### DIFF
--- a/src/city_score/city.py
+++ b/src/city_score/city.py
@@ -3,13 +3,65 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from .sources.core import Core
 
+state_names = {
+    "AL":"Alabama",
+    "AK":"Alaska",
+    "AZ":"Arizona",
+    "AR":"Arkansas",
+    "CA":"California",
+    "CO":"Colorado",
+    "CT":"Connecticut",
+    "DE":"Delaware",
+    "FL":"Florida",
+    "GA":"Georgia",
+    "HI":"Hawaii",
+    "ID":"Idaho",
+    "IL":"Illinois",
+    "IN":"Indiana",
+    "IA":"Iowa",
+    "KS":"Kansas",
+    "KY":"Kentucky",
+    "LA":"Louisiana",
+    "ME":"Maine",
+    "MD":"Maryland",
+    "MA":"Massachusetts",
+    "MI":"Michigan",
+    "MN":"Minnesota",
+    "MS":"Mississippi",
+    "MO":"Missouri",
+    "MT":"Montana",
+    "NE":"Nebraska",
+    "NV":"Nevada",
+    "NH":"New Hampshire",
+    "NJ":"New Jersey",
+    "NM":"New Mexico",
+    "NY":"New York",
+    "NC":"North Carolina",
+    "ND":"North Dakota",
+    "OH":"Ohio",
+    "OK":"Oklahoma",
+    "OR":"Oregon",
+    "PA":"Pennsylvania",
+    "RI":"Rhode Island",
+    "SC":"South Carolina",
+    "SD":"South Dakota",
+    "TN":"Tennessee",
+    "TX":"Texas",
+    "UT":"Utah",
+    "VT":"Vermont",
+    "VA":"Virginia",
+    "WA":"Washington",
+    "WV":"West Virginia",
+    "WI":"Wisconsin",
+    "WY":"Wyoming"
+}
+
 @dataclass
 class City:
     name: str
     state: str
     lat: float
     lng: float
-    state_name: str
     data: dict = field(default_factory=dict)
     last_score: int = -1
 
@@ -27,6 +79,10 @@ class City:
     @property
     def coordinates(self):
         return (self.lat, self.lng)
+    
+    @property
+    def state_name(self):
+        return state_names[self.state]
 
     def update(self, data):
         self.data.update(data)
@@ -59,7 +115,7 @@ def get_cities():
     with Core.open('cities.csv') as f:
         city_reader = csv.DictReader(f)
         for city_row in city_reader:
-            city = City(city_row['CITY'], city_row['STATE_CODE'], float(city_row['LATITUDE']), float(city_row['LONGITUDE']), city_row['STATE_NAME'])
+            city = City(city_row['CITY'], city_row['STATE_CODE'], float(city_row['LATITUDE']), float(city_row['LONGITUDE']))
             city_str = str(city)
 
             if city_str in city_strs:

--- a/src/city_score/city.py
+++ b/src/city_score/city.py
@@ -9,6 +9,7 @@ class City:
     state: str
     lat: float
     lng: float
+    state_name: str
     data: dict = field(default_factory=dict)
     last_score: int = -1
 
@@ -58,11 +59,10 @@ def get_cities():
     with Core.open('cities.csv') as f:
         city_reader = csv.DictReader(f)
         for city_row in city_reader:
-            city = City(city_row['CITY'], city_row['STATE_CODE'], float(city_row['LATITUDE']), float(city_row['LONGITUDE']))
+            city = City(city_row['CITY'], city_row['STATE_CODE'], float(city_row['LATITUDE']), float(city_row['LONGITUDE']), city_row['STATE_NAME'])
             city_str = str(city)
 
             if city_str in city_strs:
                 continue
-
             city_strs.add(city_str)
             yield city

--- a/src/city_score/sources/tpl_parks.py
+++ b/src/city_score/sources/tpl_parks.py
@@ -46,7 +46,6 @@ def nearby_parks_accessibility(city):
         parser = TrustForPublicLandResultParser()
         parser.feed(response.text)
         cache.set(key, parser.text_content)
-        print(parser.text_content)
         return parser.text_content
     return '?'
 

--- a/src/city_score/sources/tpl_parks.py
+++ b/src/city_score/sources/tpl_parks.py
@@ -1,0 +1,61 @@
+from ..cache import cache
+from ..decorators import dimension, scorer
+from ..source import Source
+from html.parser import HTMLParser
+import requests
+
+class TrustForPublicLand(Source):
+    pass
+
+class TrustForPublicLandResultParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.found = False
+        self.text_content = ""
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "div" and ("class", "bold-statement__heading") in attrs:
+            self.found = True
+        elif tag == "b" and self.found:
+            self.found = True
+
+    def handle_data(self, data):
+        if self.found:
+            self.text_content = data
+
+    def handle_endtag(self, tag):
+        if tag == "div" and self.found:
+            self.found = False
+        elif tag == "b" and self.found:
+            self.found = False
+
+@dimension("TrustForPublicLand")
+def nearby_parks_accessibility(city):
+    """Percentage of residents who live within a 10-minute walk of a park"""
+    key = 'tpl-%s' % (str(city))
+    result = cache.get(key)
+    if result is not None:
+        return result
+
+    city_name = city.name.lower().replace(' ', '-')
+    state_name = city.state_name.lower().replace(' ', '-')
+    url = f"https://www.tpl.org/city/{city_name}-{state_name}"
+    response = requests.get(url)
+
+    if response.status_code == 200:
+        parser = TrustForPublicLandResultParser()
+        parser.feed(response.text)
+        cache.set(key, parser.text_content)
+        print(parser.text_content)
+        return parser.text_content
+    return '?'
+
+@scorer("TrustForPublicLand")
+def nearby_parks_accessibility_scorer(city, lower, upper):
+    data = nearby_parks_accessibility(city)
+    perc = int(data.strip("%"))
+    if perc >= upper:
+        return 100
+    if perc >= lower:
+        return round(((perc - lower) / (upper - lower)) * 100)
+    return 0


### PR DESCRIPTION
Scrapes `tpl.org/city/{city}-{state}` and retrieves percentage of residents that live within a 10-minute walk of a park

1. Should we use some kind of better parsing library? Any gold standard packages?
2. Should this be a standalone metric? Or somehow combined with other park metrics (e.g. acreage per capita)